### PR TITLE
fix: add abstraction for block break rewards

### DIFF
--- a/src/main/java/kb/daerk/KiwiBlackPP.java
+++ b/src/main/java/kb/daerk/KiwiBlackPP.java
@@ -2,6 +2,7 @@ package kb.daerk;
 
 import kb.daerk.commands.*;
 import kb.daerk.config.FileConfigManager;
+import kb.daerk.eventListener.BlockBreakRewardsListener;
 import kb.daerk.eventListener.InventoryListener;
 import kb.daerk.eventListener.PlayerListener;
 import kb.daerk.managers.MenuInventoryManager;
@@ -75,6 +76,7 @@ public class KiwiBlackPP extends JavaPlugin {
     public void registerEvents() {
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
         getServer().getPluginManager().registerEvents(new InventoryListener(this), this);
+        getServer().getPluginManager().registerEvents(new BlockBreakRewardsListener(this), this);
     }
 
     public FileConfigManager getFileConfigManager(){

--- a/src/main/java/kb/daerk/commands/TptCommand.java
+++ b/src/main/java/kb/daerk/commands/TptCommand.java
@@ -94,6 +94,7 @@ public class TptCommand implements CommandExecutor {
         Bukkit.broadcastMessage(MessageColors.coloredMessage("&b&m------------------------------"));
         Bukkit.broadcastMessage(MessageColors.coloredMessage("&eEl jugador &a"+ player.getName() + "&e se ha"));
         Bukkit.broadcastMessage(MessageColors.coloredMessage("&eteletransportado a &a" + target.getName() + "&e."));
+        Bukkit.broadcastMessage(MessageColors.coloredMessage("&ejiji"));
         Bukkit.broadcastMessage(MessageColors.coloredMessage("&b&m------------------------------"));
 
 

--- a/src/main/java/kb/daerk/config/FileConfigManager.java
+++ b/src/main/java/kb/daerk/config/FileConfigManager.java
@@ -1,6 +1,8 @@
 package kb.daerk.config;
 
 import kb.daerk.KiwiBlackPP;
+
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.List;
@@ -19,19 +21,20 @@ public class FileConfigManager {
     private List<String> teleportInLocation;
     private String blockWordsMessage;
 
-    public FileConfigManager(KiwiBlackPP plugin){
+    private Boolean isBlockBreakRewardsEnabled;
+    ConfigurationSection blockBreakRewardsBlocksSection;
+
+    public FileConfigManager(KiwiBlackPP plugin) {
         this.plugin = plugin;
-        configFile = new CustomConfig("config.yml",null,plugin);
+        configFile = new CustomConfig("config.yml", null, plugin);
         configFile.registerConfig();
         loadConfig();
     }
 
-
     /**
      * Carga los datos de la configuración siguiendo el PATH correspondiente.
      */
-    public void loadConfig(){
-
+    public void loadConfig() {
 
         FileConfiguration config = configFile.getConfig();
         prefix = config.getString("config.prefix");
@@ -41,18 +44,22 @@ public class FileConfigManager {
         isTeleportOnJoinEnable = config.getBoolean("config.teleport_on_join.enable");
         teleportInLocation = config.getStringList("config.teleport_on_join.Location");
         blockWordsMessage = config.getString("messages.block_words_message");
+
+        isBlockBreakRewardsEnabled = config.getBoolean("config.block_break_rewards.enabled");
+        blockBreakRewardsBlocksSection = config.getConfigurationSection("config.block_break_rewards.blocks");
     }
 
     /**
      * Recarga la configuración en caso de haber hecho un cambio.
      */
-    public void reloadConfig(){
+    public void reloadConfig() {
         configFile.reloadConfig();
         loadConfig();
     }
 
     /**
-     * Se encarga de obtener los datos del "public void loadConfig" regresando sus valores asignados.
+     * Se encarga de obtener los datos del "public void loadConfig" regresando sus
+     * valores asignados.
      */
     public String getPreventBlockBreakMessage() {
         return preventBlockBreakMessage;
@@ -79,6 +86,23 @@ public class FileConfigManager {
     }
 
     public String getPrefix() {
-     return prefix;
+        return prefix;
     }
+
+    public Boolean getIsBlockBreakRewardsEnabled() {
+        return isBlockBreakRewardsEnabled;
+    }
+
+    public Boolean getIsBlockBreakRewardsBlockAllowed(String blockName) {
+        return blockBreakRewardsBlocksSection.contains(blockName);
+    }
+
+    public double getBlockBreakRewardsBlockChance(String blockName) {
+        return blockBreakRewardsBlocksSection.getDouble(blockName + ".chance", 0.0);
+    }
+
+    public Integer getBlockBreakRewardBlockMultiplier(String blockName) {
+        return blockBreakRewardsBlocksSection.getInt(blockName + ".multiplier", 0);
+    }
+
 }

--- a/src/main/java/kb/daerk/eventListener/BlockBreakRewardsListener.java
+++ b/src/main/java/kb/daerk/eventListener/BlockBreakRewardsListener.java
@@ -1,0 +1,76 @@
+package kb.daerk.eventListener;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import kb.daerk.KiwiBlackPP;
+import kb.daerk.tools.MessageColors;
+
+/*
+ * Handles the logic behind Block Break Rewards
+ * 
+ * Allows configuring any block type to duplicate the given rewards
+ */
+public class BlockBreakRewardsListener implements Listener {
+
+    KiwiBlackPP plugin;
+
+    public BlockBreakRewardsListener(KiwiBlackPP plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        // Abort if module is not enabled
+        if (!plugin.getFileConfigManager().getIsBlockBreakRewardsEnabled())
+            return;
+
+        // Abort if player has no permission
+        if (!event.getPlayer().hasPermission("kiwiblack.block.break"))
+            return;
+            
+        // Abort if player is mining silk touch to prevent infinite dupes
+        if (event.getPlayer().getInventory().getItemInMainHand().containsEnchantment(Enchantment.SILK_TOUCH))
+            return;
+
+        // Check if block matches configured rewards
+        if (!plugin.getFileConfigManager().getIsBlockBreakRewardsBlockAllowed(event.getBlock().getType().name()))
+            return;
+
+        // Evaluate random chance
+        if (plugin.getFileConfigManager().getBlockBreakRewardsBlockChance(event.getBlock().getType().name()) < ThreadLocalRandom.current().nextDouble(100))
+            return;
+
+        int dropsReceived = 0;
+        String dropName = "";
+
+        // Give the extra drops to the player
+        for (ItemStack blockDrop : event.getBlock().getDrops()) {
+            int dropsToGive = (int) Math.ceil(blockDrop.getAmount() * plugin.getFileConfigManager().getBlockBreakRewardBlockMultiplier(event.getBlock().getType().name()));
+            blockDrop.setAmount(dropsToGive);
+            Map<Integer, ItemStack> outOfSpaceItems = event.getPlayer().getInventory().addItem(blockDrop);
+
+            // If no inventory space is available, drop them
+            if (outOfSpaceItems.size() > 0) {
+                for (ItemStack leftover : outOfSpaceItems.values()) {
+                    event.getPlayer().getWorld().dropItemNaturally(event.getPlayer().getLocation(), leftover);
+                }
+            }
+
+            dropName = blockDrop.getType().name();
+            dropsReceived += dropsToGive;
+
+        }
+
+        event.getPlayer().sendMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aHas encontrado &e" + dropsReceived + " " + dropName + " mas"));
+        plugin.getServer().broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aEl jugador &e" + event.getPlayer().getName() + "&a ha encontrado &ex"+ dropsReceived +" "+ dropName +" extra."));
+
+    }
+
+}

--- a/src/main/java/kb/daerk/eventListener/PlayerListener.java
+++ b/src/main/java/kb/daerk/eventListener/PlayerListener.java
@@ -2,24 +2,16 @@ package kb.daerk.eventListener;
 
 import kb.daerk.KiwiBlackPP;
 import kb.daerk.config.FileConfigManager;
-import kb.daerk.tools.ItemTools;
 import kb.daerk.tools.MessageColors;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
-import java.util.Random;
-import java.util.Set;
-
 
 public class PlayerListener implements Listener {
 
@@ -74,104 +66,4 @@ public class PlayerListener implements Listener {
         }
     }
 
-
-        /**
-         * Eventos que ocurren al romper un bloque.
-         */
-        @EventHandler
-        public void onBlockBreak (BlockBreakEvent event){
-            Player player = event.getPlayer();
-
-            Set<Material> hierrosValidos = Set.of(Material.IRON_ORE, Material.DEEPSLATE_IRON_ORE);
-            Set<Material> orosValidos = Set.of(Material.GOLD_ORE, Material.DEEPSLATE_GOLD_ORE);
-            Set<Material> diamantesValidos = Set.of(Material.DIAMOND_ORE, Material.DEEPSLATE_DIAMOND_ORE);
-            Set<Material> esmeraldasValidas = Set.of(Material.EMERALD_ORE, Material.DEEPSLATE_EMERALD_ORE);
-            Set<Material> carbonValido = Set.of(Material.COAL_ORE, Material.DEEPSLATE_COAL_ORE);
-            Set<Material> lapizValida = Set.of(Material.LAPIS_ORE, Material.DEEPSLATE_LAPIS_ORE);
-
-
-
-            if (player.getWorld().getName().equals("world") && player.hasPermission("kiwiblack.block.break")) {
-                event.setCancelled(true);
-                player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix()+ plugin.getFileConfigManager().getPreventBlockBreakMessage()));
-            }
-
-            // DIAMANTE
-            Block block = event.getBlock();
-            if(diamantesValidos.contains(block.getType())){
-                int num = new Random().nextInt(10);
-                if(num == 0){
-                    ItemStack item = ItemTools.generateDiamond(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aHas encontrado &e1 diamante extra &aal minar una mena de diamante."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 diamante&a, minando una mena de diamante."));
-                }
-            }
-
-            // ORO
-            if(orosValidos.contains(block.getType())){
-                int num = new Random().nextInt(10);
-                if(num == 0){
-                    ItemStack item = ItemTools.generateRawGold(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aHas encontrado &e1 oro crudo extra &aal minar una mena de oro."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 oro crudo&a, minando una mena de oro."));
-                }
-            }
-
-            // HIERRO
-            if(hierrosValidos.contains(block.getType())){
-                int num = new Random().nextInt(10);
-                if(num == 0){
-                    ItemStack item = ItemTools.generateRawIron(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aHas encontrado &e1 hierro crudo extra &aal minar una mena de hierro."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 hierro crudo&a, minando una mena de hierro."));
-                }
-            }
-
-            // ESMERALDA
-            if(esmeraldasValidas.contains(block.getType())){
-                int num = new Random().nextInt(10);
-                if(num >= 4){
-                    ItemStack item = ItemTools.generatePotion(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aHas encontrado &e1 poción de rescate &aal minar una mena de emeralda."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix()+ " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 poción de rescate&a, minando una mena de esmeralda."));
-                }
-            }
-
-            // CARBON
-            if(carbonValido.contains(block.getType())) {
-                int num = new Random().nextInt(10);
-                if (num == 0) {
-                    ItemStack item = ItemTools.generateCoal(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aHas encontrado &e1 carbon extra &aal minar una mena de carbon."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 carbon&a, minando una mena de carbon."));
-                }
-            }
-
-            // LAPIS
-            if(lapizValida.contains(block.getType())) {
-                int num = new Random().nextInt(10);
-                if (num == 0) {
-                    ItemStack item = ItemTools.generateLapis(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aHas encontrado &e1 lapis lazuli &aal minar una mena de lapis lazuli."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &aEl jugador &e" + player.getName() + "&a ha encontrado &ex1 lapis lazuli&a, minando una mena de lapis lazuli."));
-                }
-            }
-
-            // ANCIEN DEBRIS
-            if(block.getType().equals(Material.ANCIENT_DEBRIS)) {
-                int num = new Random().nextInt(10);
-                if (num >= 4) {
-                    ItemStack item = ItemTools.generateLapis(1);
-                    block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    player.sendMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &dHas encontrado &e1 escombro ancestral &dal minar un escombro ancestral."));
-                    Bukkit.broadcastMessage(MessageColors.coloredMessage(plugin.getPrefix() + " &dEl jugador &e" + player.getName() + "&d ha encontrado &ex1 escombro ancestral&d, minando un escombro ancestral."));
-                }
-            }
-        }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,6 +33,22 @@ config:
     - '90'         # Yaw
     - '0'          # Pitch
 
+  block_break_rewards:
+    enabled: false
+    blocks:
+      IRON_ORE:
+        chance: 25 # 25%
+        multiplier: 1.5
+      DEEPSLATE_IRON_ORE:
+        chance: 35 # 35%
+        multiplier: 1.9
+      GOLD_ORE:
+        chance: 15
+        multiplier: 1.2
+      DEEPSLATE_GOLD_ORE:
+        chance: 20
+        multiplier: 1.3
+
 messages:
   prevent_block_break: " &c¡No puedes romper bloques aquí!"
 


### PR DESCRIPTION
Changes stand for:

- Moved Block Break Rewards from PlayerListener to BlockBreakRewardsListener
- Moved "allowed blocks" to config.yml
- Deleted old code from PlayerListener
- Removed event.setCancelled(true) when player has no permission as this prevents block breaking for all players without this permission.
- Added chance and multiplier variables for better control over the rewards